### PR TITLE
Configure responsive-dashboard.yaml as main default dashboard

### DIFF
--- a/dashboard.yaml
+++ b/dashboard.yaml
@@ -16,7 +16,7 @@ views:
     cards:
       # Main Navigation Header
       - type: custom:mushroom-title-card
-        title: "<Û House Atreides Central Command"
+        title: "<ï¿½ House Atreides Central Command"
         subtitle: "Navigate to specialized control systems"
         card_mod:
           style: |
@@ -37,7 +37,7 @@ views:
             secondary_info: "Main responsive dashboard with comprehensive controls"
             tap_action:
               action: navigate
-              navigation_path: /lovelace-responsive-dashboard
+              navigation_path: /lovelace/0
             card_mod:
               style: |
                 ha-card {
@@ -100,7 +100,7 @@ views:
 
       # Quick Status Grid
       - type: entities
-        title: "=Ê Quick System Status"
+        title: "=ï¿½ Quick System Status"
         entities:
           - entity: binary_sensor.house_occupied
             name: "House Occupied"

--- a/integrations/lovelace.yaml
+++ b/integrations/lovelace.yaml
@@ -1,0 +1,42 @@
+---
+# Lovelace Dashboard Configuration - Multiple Dashboard Setup
+# https://www.home-assistant.io/integrations/lovelace/
+
+lovelace:
+  # Main dashboard configuration - Mobile Responsive
+  mode: yaml
+  filename: responsive-dashboard.yaml
+  
+  # Additional dashboards
+  dashboards:
+    # Navigation hub dashboard
+    lovelace-dashboard-nav:
+      mode: yaml
+      title: "Dashboard Navigation"
+      icon: mdi:view-dashboard
+      show_in_sidebar: true
+      filename: dashboard.yaml
+      
+    # Sietch command center - advanced analytics
+    dashboards-sietch_command:
+      mode: yaml  
+      title: "Sietch Command Center"
+      icon: mdi:console-network
+      show_in_sidebar: true
+      filename: dashboards/sietch_command.yaml
+      
+    # Performance monitoring dashboard
+    dashboards-performance_monitoring:
+      mode: yaml
+      title: "Mentat Analytics"
+      icon: mdi:speedometer
+      show_in_sidebar: true
+      filename: dashboards/performance_monitoring.yaml
+      
+    # Mobile command dashboard  
+    dashboards-mobile_command:
+      mode: yaml
+      title: "Mobile Command"
+      icon: mdi:cellphone
+      show_in_sidebar: true
+      filename: dashboards/mobile_command.yaml


### PR DESCRIPTION
- Set responsive-dashboard.yaml as the main lovelace dashboard for mobile responsiveness
- Move dashboard.yaml to secondary sidebar dashboard for navigation
- Update navigation paths to point to correct dashboard URLs
- Ensures mobile-first experience with comprehensive controls as default

🤖 Generated with [Claude Code](https://claude.ai/code)