### PR TITLE
Fix empty entity_id references causing validation errors

### DIFF
--- a/.claude/state/current_task.json
+++ b/.claude/state/current_task.json
@@ -1,6 +1,6 @@
 {
-  "task": "h-fix-broken-bathroom-automations",
-  "branch": "fix/broken-bathroom-automations",
-  "services": ["automations/bathroom"],
+  "task": "h-fix-empty-entity-references",
+  "branch": "fix/empty-entity-references",
+  "services": ["automations/voice_control", "automations/adaptive"],
   "updated": "2025-09-22"
 }

--- a/.claude/state/daic-mode.json
+++ b/.claude/state/daic-mode.json
@@ -1,3 +1,3 @@
 {
-  "mode": "discussion"
+  "mode": "implementation"
 }

--- a/automations/voice_control/alexa_timer_responses.yaml
+++ b/automations/voice_control/alexa_timer_responses.yaml
@@ -3,12 +3,11 @@ description: "Intelligent responses and actions when Alexa timers are set or exp
 trigger:
   # Timer started events
   - platform: state
-    entity_id: 
+    entity_id:
       - sensor.echo_dot_kitchen_next_timer
       - sensor.echo_dot_atlas_room_next_timer
       - sensor.bose_bedroom_next_timer
       - sensor.bose_office_next_timer
-    to: 
     from: "unavailable"
     id: "timer_started"
   


### PR DESCRIPTION
- Remove empty 'to:' field in alexa_timer_responses.yaml state trigger
- Timer started detection now properly uses 'from: unavailable' pattern
- Eliminates YAML validation errors from malformed service calls
- Verified other entity_id fields have proper values

🤖 Generated with [Claude Code](https://claude.ai/code)