### PR TITLE
fix: resolve homekit and binary sensor configuration errors

### DIFF
--- a/assistants/homekit/exclude_entities.yaml
+++ b/assistants/homekit/exclude_entities.yaml
@@ -1,8 +1,6 @@
 ---
 # HomeKit Entity Exclusions
 # Excludes non-essential entities to stay under the 150 device limit
-
-exclude_entities:
   # Duplicate/redundant motion sensors
   - binary_sensor.front_door_ding_3
   - binary_sensor.front_door_motion_3

--- a/entities/binary_sensor/system_status.yaml
+++ b/entities/binary_sensor/system_status.yaml
@@ -2,6 +2,7 @@
 # System Status Binary Sensors - Dune Monitoring Network
 # Critical status indicators for system health and security
 
+binary_sensor:
 - name: "House Occupied"
   unique_id: "house_occupied"
   state: >-


### PR DESCRIPTION
- Remove duplicate exclude_entities key from homekit YAML (fixes HomeKit config)
- Add missing binary_sensor key to system_status.yaml (fixes template sensor loading)

🤖 Generated with [Claude Code](https://claude.ai/code)